### PR TITLE
DRAFT: adjusting display of relatedItems

### DIFF
--- a/scripts/overrides/tei_to_html.xsl
+++ b/scripts/overrides/tei_to_html.xsl
@@ -132,17 +132,7 @@
                 </a>
                 <xsl:text>.</xsl:text></li>
             </xsl:for-each>
-            
-            <xsl:for-each select="//relatedItem[@type = 'document']">
-              <li>
-                <xsl:text> See </xsl:text>
-                <a>
-                  <xsl:attribute name="href" select="@target"/>
-                  <xsl:value-of select="@target"/>
-                </a>
-                <xsl:text>.</xsl:text>
-              </li>
-            </xsl:for-each>
+           
           </ul>          
         </li>
       </xsl:if>


### PR DESCRIPTION
This includes the following edits: 

- address broken links in relatedItems display, per https://github.com/whitmanarchive/whitman-issues/issues/699 ((remove document type from display, as this was not included in the cocoon site)